### PR TITLE
Avoid dereferencing null ptr on optional arg, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build system and IDEs
+build*/
+.project
+.cproject
+.settings/
+.vscode/

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -1036,7 +1036,10 @@ bool realsense2Driver::getImage(FlexImage& Frame, Stamp *timeStamp, rs2::framese
 
     memcpy((void*)Frame.getRawImage(), (void*)color_frm.get_data(), mem_to_wrt);
     m_rgb_stamp.update();
-    *timeStamp = m_rgb_stamp;
+    if (timeStamp != nullptr)
+    {
+        *timeStamp = m_rgb_stamp;
+    }
     return true;
 }
 
@@ -1067,7 +1070,10 @@ bool realsense2Driver::getImage(depthImage& Frame, Stamp *timeStamp, const rs2::
     }
 
     m_depth_stamp.update();
-    *timeStamp   = m_depth_stamp;
+    if (timeStamp != nullptr)
+    {
+        *timeStamp = m_depth_stamp;
+    }
     return true;
 }
 


### PR DESCRIPTION
Not much to add here, I ran into this bug while trying to call `IRGBDSensor::getRgbImage(image)` or `IRGBDSensor::getDepthImage(image)` with no second optional parameter (pointer to timestamp, defaulted to NULL).

Also adding `.gitignore` with targeted `build` folder and Eclipse/VScode IDE-related stuff.