### PR TITLE
Stream T256 tracking camera pose using `analogServer` device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `analogServer` device to stream T256 pose. (See [!18](https://github.com/robotology/yarp-device-realsense2/pull/18)).
 
 ## [0.1.0] - 2021-04-27
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ The type on information currently made available are:
 - the Accelerometer measures, and
 - the Pose (position and orientation).
 
+You can also publish RealSense T256 pose using the `analogServer` device. Run it using:
+
+```bash
+yarpdev --device analogServer --name /t265 --period 10 --subdevice realsense2Tracking
+```
+
+:bulb: **NOTE:** also here, the user should specify the parameters `--name` and `--period` as needed.
+
+The command will open a port `/t256` that streams the pose as follows:
+
+```
+<positionX positionY positionZ QuaternionW QuaternionX QuaternionY QuaternionZ>
+```
 
 ## Device documentation
 

--- a/src/devices/realsense2/realsense2Tracking.cpp
+++ b/src/devices/realsense2/realsense2Tracking.cpp
@@ -217,6 +217,7 @@ bool realsense2Tracking::open(Searchable& config)
         return false;
     }
 
+    m_pose_data.resize(7);
     return true;
 }
 
@@ -459,6 +460,90 @@ bool realsense2Tracking::getPositionSensorMeasure(size_t sens_index, yarp::sig::
     xyz[2] = m_last_pose.translation.z;
     return true;
 }
+/*
+bool realsense2Tracking::read(yarp::sig::Vector& out)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first_or_default(RS2_STREAM_POSE);
+    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
+    m_last_pose = pose.get_pose_data();
+
+    out.resize(7);
+    out[0] = m_last_pose.translation.x;
+    out[1] = m_last_pose.translation.y;
+    out[2] = m_last_pose.translation.z;
+    out[3] = m_last_pose.rotation.x;
+    out[4] = m_last_pose.rotation.y;
+    out[5] = m_last_pose.rotation.z;
+    out[6] = m_last_pose.rotation.w;
+
+    return true;
+}
+
+bool realsense2Tracking::getChannels(int* nc)
+{
+    return true;
+}
+
+bool realsense2Tracking::calibrate(int ch, double v)
+{
+    return true;
+}
+*/
+
+int realsense2Tracking::read(yarp::sig::Vector& out)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    rs2::frameset dataframe = m_pipeline.wait_for_frames();
+    auto fa = dataframe.first_or_default(RS2_STREAM_POSE);
+    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
+    m_last_pose = pose.get_pose_data();
+
+    out.resize(7);
+    out[0] = m_last_pose.translation.x;
+    out[1] = m_last_pose.translation.y;
+    out[2] = m_last_pose.translation.z;
+    out[3] = m_last_pose.rotation.x;
+    out[4] = m_last_pose.rotation.y;
+    out[5] = m_last_pose.rotation.z;
+    out[6] = m_last_pose.rotation.w;
+    return 0;
+}
+
+int realsense2Tracking::getState(int ch)
+{
+    return 0;
+}
+
+
+int realsense2Tracking::getChannels()
+{
+    return 7;
+}
+
+int realsense2Tracking::calibrateSensor()
+{
+    return 0;
+}
+
+int realsense2Tracking::calibrateSensor(const yarp::sig::Vector& value)
+{
+    return 0;
+}
+
+int realsense2Tracking::calibrateChannel(int ch)
+{
+    return 0;
+}
+
+int realsense2Tracking::calibrateChannel(int ch, double value)
+{
+    return 0;
+}
+
+
+
 
 //-------------------------------------------------------------------------------------------------------
 #if 0

--- a/src/devices/realsense2/realsense2Tracking.cpp
+++ b/src/devices/realsense2/realsense2Tracking.cpp
@@ -504,10 +504,10 @@ int realsense2Tracking::read(yarp::sig::Vector& out)
     out[0] = m_last_pose.translation.x;
     out[1] = m_last_pose.translation.y;
     out[2] = m_last_pose.translation.z;
-    out[3] = m_last_pose.rotation.x;
-    out[4] = m_last_pose.rotation.y;
-    out[5] = m_last_pose.rotation.z;
-    out[6] = m_last_pose.rotation.w;
+    out[3] = m_last_pose.rotation.w;
+    out[4] = m_last_pose.rotation.x;
+    out[5] = m_last_pose.rotation.y;
+    out[6] = m_last_pose.rotation.z;
     return 0;
 }
 

--- a/src/devices/realsense2/realsense2Tracking.cpp
+++ b/src/devices/realsense2/realsense2Tracking.cpp
@@ -217,7 +217,6 @@ bool realsense2Tracking::open(Searchable& config)
         return false;
     }
 
-    m_pose_data.resize(7);
     return true;
 }
 
@@ -460,40 +459,11 @@ bool realsense2Tracking::getPositionSensorMeasure(size_t sens_index, yarp::sig::
     xyz[2] = m_last_pose.translation.z;
     return true;
 }
-/*
-bool realsense2Tracking::read(yarp::sig::Vector& out)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    rs2::frameset dataframe = m_pipeline.wait_for_frames();
-    auto fa = dataframe.first_or_default(RS2_STREAM_POSE);
-    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
-    m_last_pose = pose.get_pose_data();
-
-    out.resize(7);
-    out[0] = m_last_pose.translation.x;
-    out[1] = m_last_pose.translation.y;
-    out[2] = m_last_pose.translation.z;
-    out[3] = m_last_pose.rotation.x;
-    out[4] = m_last_pose.rotation.y;
-    out[5] = m_last_pose.rotation.z;
-    out[6] = m_last_pose.rotation.w;
-
-    return true;
-}
-
-bool realsense2Tracking::getChannels(int* nc)
-{
-    return true;
-}
-
-bool realsense2Tracking::calibrate(int ch, double v)
-{
-    return true;
-}
-*/
 
 int realsense2Tracking::read(yarp::sig::Vector& out)
 {
+    // Publishes the data in the analog port as:
+    // <positionX positionY positionZ QuaternionW QuaternionX QuaternionY QuaternionZ>
     std::lock_guard<std::mutex> guard(m_mutex);
     rs2::frameset dataframe = m_pipeline.wait_for_frames();
     auto fa = dataframe.first_or_default(RS2_STREAM_POSE);

--- a/src/devices/realsense2/realsense2Tracking.h
+++ b/src/devices/realsense2/realsense2Tracking.h
@@ -13,7 +13,6 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
-#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/IAnalogSensor.h>
 
 #include "realsense2Driver.h"
@@ -34,7 +33,6 @@ class realsense2Tracking :
         public yarp::dev::IThreeAxisLinearAccelerometers,
         public yarp::dev::IOrientationSensors,
         public yarp::dev::IPositionSensors,
-        //public yarp::dev::IGenericSensor,
         public yarp::dev::IAnalogSensor
 {
 private:
@@ -87,11 +85,6 @@ public:
     bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
     bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
-    /* IGenericSensor methods */
-    //bool read(yarp::sig::Vector &out) override;
-    //bool getChannels(int *nc) override;
-    //bool calibrate(int ch, double v) override;
-
     /* IAnalogSensor methods */
     int read(yarp::sig::Vector &out) override;
     int getState(int ch) override;
@@ -137,7 +130,6 @@ protected:
     enum timestamp_enumtype {yarp_timestamp=0, rs_timestamp};
     timestamp_enumtype m_timestamp_type;
 
-    yarp::sig::Vector m_pose_data;
     /*
     rs2::context m_ctx;
 

--- a/src/devices/realsense2/realsense2Tracking.h
+++ b/src/devices/realsense2/realsense2Tracking.h
@@ -13,6 +13,8 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
+#include <yarp/dev/IAnalogSensor.h>
 
 #include "realsense2Driver.h"
 #include <cstring>
@@ -31,7 +33,9 @@ class realsense2Tracking :
         public yarp::dev::IThreeAxisGyroscopes,
         public yarp::dev::IThreeAxisLinearAccelerometers,
         public yarp::dev::IOrientationSensors,
-        public yarp::dev::IPositionSensors
+        public yarp::dev::IPositionSensors,
+        //public yarp::dev::IGenericSensor,
+        public yarp::dev::IAnalogSensor
 {
 private:
     typedef yarp::os::Stamp Stamp;
@@ -83,6 +87,20 @@ public:
     bool getPositionSensorFrameName(size_t sens_index, std::string& frameName) const override;
     bool getPositionSensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
+    /* IGenericSensor methods */
+    //bool read(yarp::sig::Vector &out) override;
+    //bool getChannels(int *nc) override;
+    //bool calibrate(int ch, double v) override;
+
+    /* IAnalogSensor methods */
+    int read(yarp::sig::Vector &out) override;
+    int getState(int ch) override;
+    int getChannels() override;
+    int calibrateSensor() override;
+    int calibrateSensor(const yarp::sig::Vector& value) override;
+    int calibrateChannel(int ch) override;
+    int calibrateChannel(int ch, double value) override;
+
 #if 0
     /* IPoseSensors methods */
     size_t getNrOfPoseSensors() const ;
@@ -119,6 +137,7 @@ protected:
     enum timestamp_enumtype {yarp_timestamp=0, rs_timestamp};
     timestamp_enumtype m_timestamp_type;
 
+    yarp::sig::Vector m_pose_data;
     /*
     rs2::context m_ctx;
 


### PR DESCRIPTION
Details in https://github.com/robotology/yarp-device-realsense2/issues/7.

### With this PR:

You can also publish RealSense T256 pose using the `analogServer` device. Run it using:

```bash
yarpdev --device analogServer --name /t265 --period 10 --subdevice realsense2Tracking
```

:bulb: **NOTE:** also here, the user should specify the parameters `--name` and `--period` as needed.

The command will open a port `/t256` that streams the pose as follows:

```
<positionX positionY positionZ QuaternionW QuaternionX QuaternionY QuaternionZ>
```