### PR TITLE
Bump version to 0.2.0 and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2021-05-28
+
 ### Added
 - Added `analogServer` device to stream T256 pose. (See [!18](https://github.com/robotology/yarp-device-realsense2/pull/18)).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(yarp-device-realsense2
         LANGUAGES CXX
-        VERSION 0.1.0)
+        VERSION 0.2.0)
 
 include(FeatureSummary)
 


### PR DESCRIPTION
Release 0.2.0 with @HosameldinMohamed's improvements from https://github.com/robotology/yarp-device-realsense2/pull/19 .