### PR TITLE
T265 with fisheye camera

### DIFF
--- a/app/devices/realsense2Tracking/realsense2Tracking.xml
+++ b/app/devices/realsense2Tracking/realsense2Tracking.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="t265-camera" build="2" portprefix="test" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <xi:include href="./sensors/realsense.xml" />
+        <xi:include href="./wrappers/grabber_yarp.xml" />
+        <xi:include href="./wrappers/pose_yarp.xml" />
+        <!--<xi:include href="./wrappers/pose_ros.xml" />-->
+    </devices>
+</robot>

--- a/app/devices/realsense2Tracking/sensors/realsense.xml
+++ b/app/devices/realsense2Tracking/sensors/realsense.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="realsense2dev" type="realsense2Tracking">
+    <group name="SETTINGS">
+        <param name="enableFisheyeStream"> 1 </param>
+    </group>
+</device>

--- a/app/devices/realsense2Tracking/wrappers/grabber_yarp.xml
+++ b/app/devices/realsense2Tracking/wrappers/grabber_yarp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="grabberDual_YARP" type="grabberDual">
+    <param name="period"> 33 </param>
+    <param name="name">    /camera:o </param>
+    <param name="capabilities"> RAW </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="subdevicergbd"> realsense2dev </elem> 
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="5" type="detach" />
+</device>

--- a/app/devices/realsense2Tracking/wrappers/pose_ros.xml
+++ b/app/devices/realsense2Tracking/wrappers/pose_ros.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="pose_ROS" type="PoseStampedRosPublisher">
+    <param name="period"> 0.01 </param>
+    <param name="name">    /tracking </param>
+    <param name="topic">  /ros_tracking </param>
+    <param name="node_name">  /tracking_node </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="subdevicergbd"> realsense2dev </elem> 
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="5" type="detach" />
+</device>

--- a/app/devices/realsense2Tracking/wrappers/pose_yarp.xml
+++ b/app/devices/realsense2Tracking/wrappers/pose_yarp.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="pose_YARP" type="multipleanalogsensorsserver">
+    <param name="period"> 10 </param>
+    <param name="name">    /tracking </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="subdevicergbd"> realsense2dev </elem> 
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="5" type="detach" />
+</device>

--- a/app/devices/realsense2Tracking/yarprobotinterface.ini
+++ b/app/devices/realsense2Tracking/yarprobotinterface.ini
@@ -1,0 +1,1 @@
+config ./realsense2Tracking.xml

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -21,6 +21,7 @@
 #include <yarp/sig/Matrix.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IRGBDSensor.h>
+#include <yarp/dev/FrameGrabberInterfaces.h >
 #include <yarp/dev/RGBDSensorParamParser.h>
 #include <librealsense2/rs.hpp>
 


### PR DESCRIPTION
* added IFrameGrabberImageRaw interface to stream one fisheye camera
* major refactor: a periodic thread is now used to sample the measurements from librealsense2 and store them in an internal buffer, accessed by the various get methods
* added usage example with yarprobotinterface: it instantiates the device plus multiple wrappers for yarp and ros. Just yarprobotinterface from folder app/devices/realsense2Tracking