### PR TITLE
fixed import that was deprecated in yarp 3.0 and removed in yarp 3.7

### DIFF
--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -15,7 +15,8 @@
 #include <mutex>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberControl2.h>
+#include <yarp/dev/IFrameGrabberControls.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/sig/all.h>
 #include <yarp/sig/Matrix.h>


### PR DESCRIPTION
since in yarp 3.7 was removed FrameGrabberControls2.h (https://github.com/robotology/yarp/commit/5253f6fb129e8be531c4bbe2b2d4f2425aff8de1) this fixes the compilation against master.
