### PR TITLE
Depth quantization and fixes to image rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `rotateImage180` parameter to rotate the image when the camera is mounted upside down (https://github.com/robotology/yarp-device-realsense2/pull/27).
 
+- Added `QUANT_PARAM` group parameter with `depth_quant` parameter (integer) to limit decimal places in depth image  (https://github.com/robotology/yarp-device-realsense2/pull/30).
+
 ### Changed
 - If all the distortion parameters are zero, explicitly specify that the image has `YARP_DISTORTION_NONE` distortion (https://github.com/robotology/yarp-device-realsense2/pull/26).
 - Changed minimum required YARP version to 3.5 (https://github.com/robotology/yarp-device-realsense2/pull/26).

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -133,6 +133,10 @@ protected:
     rs2_stream  m_alignment_stream{RS2_STREAM_COLOR};
 
 
+    // Data quantization related parameters
+    bool                             m_depthQuantizationEnabled{false};
+    int                              m_depthDecimalNum{0};
+
     yarp::os::Stamp m_rgb_stamp;
     yarp::os::Stamp m_depth_stamp;
     mutable std::string m_lastError;


### PR DESCRIPTION
based on #29, this adds the quantization of the realsense in order to save some bandwidth  with the compression (as made in gazebo https://github.com/robotology/gazebo-yarp-plugins/pull/608) 
There is also a bugfix of image rotation introduced in https://github.com/robotology/yarp-device-realsense2/pull/27