### PR TITLE
Initialize the rotation estimator pointer in realsense2withIMUDriver constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If all the distortion parameters are zero, explicitly specify that the image has `YARP_DISTORTION_NONE` distortion (https://github.com/robotology/yarp-device-realsense2/pull/26).
 - Changed minimum required YARP version to 3.5 (https://github.com/robotology/yarp-device-realsense2/pull/26).
 
+### Fixed
+- Fixed support for `D435i` (https://github.com/robotology/yarp-device-realsense2/pull/36). 
+
 ## [0.2.0] - 2021-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can write a yarp application to launch the camera and see the RGB and Depth 
 
 Set the `YARP_ROBOT_NAME` to either `CER01`, `CER02` or `CER03`. Then, run the command:
 
-```bash
+```console
 yarpdev --from sensors/RealSense_conf.ini
 ```
 
@@ -145,7 +145,42 @@ clipPlanes (0.2 10.0)
 
 ### How to use a RealSense D435i
 
-:construction: UNDER CONSTRUCTION :construction:
+The device retrieving the  RealSense D435i data is the `multipleanalogsensorserver` and it must be run as follows:
+
+```console
+yarpdev --from sensors/RealSense_conf.ini
+```
+
+however differently from the Realsense D435 the  `sensors/RealSense_conf.ini` contains the following settings:
+
+```ini
+device       multipleanalogsensorsserver
+subdevice    realsense2withIMU
+name         /depthCamera
+period       10
+
+[SETTINGS]
+depthResolution (640 480)
+rgbResolution   (640 480)
+framerate       30
+enableEmitter   true
+alignmentFrame  RGB
+
+[HW_DESCRIPTION]
+clipPlanes (0.2 10.0)
+```
+
+As you can notice the device now is a `multipleanalogsensorsserver`.
+
+The data from a RealSense D435i will be streamed on the port named `/depthCamera/measures:o` following the format described in the `SensorStreamingData` class.
+
+The type of information currently made available are:
+
+- the Gyroscope measures,
+- the Accelerometer measures,
+- the orientation.
+
+:bulb: **NOTE:** The  Gyroscope and the Accelerometer data are directly retrieved from the RealSense. On the other hand, the RealSense D435i does not provide a routine to get its orientation. To give the user also this information, this device implements a [complementary filter](https://github.com/robotology/yarp-device-realsense2/blob/d4da73fa2336c40d7d479bb8ee87c317f2128c9b/src/devices/realsense2/realsense2withIMUDriver.cpp#L73-L111) that estimates the RealSense orientation from the accelerometer and gyroscope readouts. :warning: The image streaming is **not** used to estimate the orientation. 
 
 ### How to use a RealSense T256
 
@@ -153,7 +188,7 @@ clipPlanes (0.2 10.0)
 
 The device retrieving the  RealSense T256 data is the `multipleanalogsensorserver` and it must be run as follows:
 
-```bash
+```console
 yarpdev --device multipleanalogsensorsserver --name /t256 --period 10 --subdevice realsense2Tracking
 ```
 

--- a/src/devices/realsense2/realsense2withIMUDriver.cpp
+++ b/src/devices/realsense2/realsense2withIMUDriver.cpp
@@ -230,8 +230,10 @@ static void settingErrorMsg(const string& error, bool& ret)
 realsense2withIMUDriver::realsense2withIMUDriver() :
         realsense2Driver()
 {
-    m_rotation_estimator=nullptr;
+    m_rotation_estimator=std::make_unique<rotation_estimator>();
 }
+
+realsense2withIMUDriver::~realsense2withIMUDriver() = default;
 
 #if 0
 bool realsense2withIMUDriver::pipelineStartup()

--- a/src/devices/realsense2/realsense2withIMUDriver.h
+++ b/src/devices/realsense2/realsense2withIMUDriver.h
@@ -40,7 +40,7 @@ private:
 
 public:
     realsense2withIMUDriver();
-    ~realsense2withIMUDriver() override = default;
+    ~realsense2withIMUDriver() override;
 
     // DeviceDriver
     bool open(yarp::os::Searchable& config) override;
@@ -85,7 +85,7 @@ protected:
     mutable rs2_vector m_last_gyro;
     mutable rs2_vector m_last_accel;
     mutable rs2_pose   m_last_pose;
-    mutable rotation_estimator* m_rotation_estimator;
+    std::unique_ptr<rotation_estimator> m_rotation_estimator;
 
     bool m_sensor_has_orientation_estimator;
 


### PR DESCRIPTION
This fixes #35, moreover, I also wrote the documentation for the RealSense D435i in the README

cc @traversaro 