### PR TITLE
Change references from RGBDSensorWrapper to rgbdSensor_nws_yarp

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ Before proceeding further, please install the following dependencies:
 
 - [librealsense](https://github.com/IntelRealSense/librealsense)
 
-### Configure YARP
+### YARP compilation from source
 
-Before proceeding further, please enable the following CMake flags in YARP:
+If you are using `yarp` binary package from conda-forge or you compiled `yarp` via the `robotology-superbuild`, go to the next section.
+
+**Only** if instead you manually compiled YARP, please make sure that the following CMake flags are enabled in the YARP CMake build:
 ```
-ENABLE_yarpmod_RGBDSensorWrapper
+ENABLE_yarpmod_rgbdSensor_nws_yarp
 ENABLE_yarpmod_RGBDSensorClient
 ENABLE_yarpcar_mjpeg
 ENABLE_yarppm_depthimage_to_rgb
 ```
-
-:bulb: **NOTE:** If you use YARP < 3.5, instead of the option `ENABLE_yarppm_depthimage_to_rgb` you should enable the option `ENABLE_yarpcar_depthimage2`.
 
 ### Build and install yarp-device-realsense2
 
@@ -129,7 +129,7 @@ By setting the `YARP_ROBOT_NAME`, YARP finds the configuration file `RealSense_c
 `RealSense_conf.ini` contains the following settings:
 
 ```ini
-device       RGBDSensorWrapper
+device       rgbdSensor_nws_yarp
 subdevice    realsense2
 name         /depthCamera
 
@@ -159,7 +159,7 @@ To use this model of camera you can follow the same instructions above with the 
 Considering the above, a possible configuration file might be the following:
 
 ```ini
-device       RGBDSensorWrapper
+device       rgbdSensor_nws_yarp
 subdevice    realsense2
 name         /depthCamera
 
@@ -204,7 +204,7 @@ This device driver exposes the `yarp::dev::IRGBDSensor` and
 the available settings.
 See the documentation for more details about each interface.
 
-This device is paired with its server called `RGBDSensorWrapper` to stream the
+This device is paired with its server called `rgbdSensor_nws_yarp` to stream the
 images and perform remote operations.
 
 The configuration file is subdivided into 2 major sections called `SETTINGS` and
@@ -271,7 +271,7 @@ Parameters used by this device are:
 Configuration file using `.ini` format, for using as RGBD device:
 
 ```ini
-device       RGBDSensorWrapper
+device       rgbdSensor_nws_yarp
 subdevice    realsense2
 name         /depthCamera
 

--- a/src/devices/realsense2/CMakeLists.txt
+++ b/src/devices/realsense2/CMakeLists.txt
@@ -8,7 +8,7 @@ yarp_prepare_plugin(realsense2
   CATEGORY device
   TYPE realsense2Driver
   INCLUDE realsense2Driver.h
-  EXTRA_CONFIG WRAPPER=RGBDSensorWrapper
+  EXTRA_CONFIG WRAPPER=rgbdSensor_nws_yarp
   DEPENDS "realsense2_FOUND"
   DEFAULT ON
 )
@@ -46,7 +46,7 @@ yarp_prepare_plugin(realsense2withIMU
   CATEGORY device
   TYPE realsense2withIMUDriver
   INCLUDE realsense2withIMUDriver.h
-  EXTRA_CONFIG WRAPPER=RGBDSensorWrapper
+  EXTRA_CONFIG WRAPPER=rgbdSensor_nws_yarp
   DEPENDS "TARGET YARP::YARP_math;realsense2_FOUND;"
   DEFAULT ON
 )


### PR DESCRIPTION
The `RGBDSensorWrapper` device was deprecated in YARP 3.5 and removed in YARP 3.8 (see https://github.com/robotology/yarp/commit/4da405c7fb077b4604029fd87e4e51a633e2d7eb) and it has been substituted by `rgbdSensor_nws_yarp`. Note that the corresponding network wrapper client (`nwc`) device that reads the rgbd data from a YARP port is called `RGBDSensorClient`.

However, there was still docs that was referring to `RGBDSensorWrapper`, this PR fixes those occurrences. Similar to https://github.com/robotology/yarp/pull/3150 .

fyi @nicktrem @davidegorbani 