### PR TITLE
Release 0.3.1 and document that CHANGELOG is not going to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This file documents notable changes to this project done before July 2023. 
+For changes after that date, plase refers to the release notes of each release at https://github.com/robotology/yarp-device-realsense2/releases .
 
-## [Unreleased]
 
 ## [0.3.0] - 2023-07-11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(yarp-device-realsense2
         LANGUAGES CXX
-        VERSION 0.3.0)
+        VERSION 0.3.1)
 
 include(FeatureSummary)
 


### PR DESCRIPTION
I think it is important to make the contribution and release process as smooth as possible, and the CHANGELOG file was complicating this. I think we can rely on the automatic process of GitHub to generate the list of the changes in a given release, and if necessary we can modify manually the automatically generated release changelog.

A similar change was done in iDynTree in https://github.com/robotology/idyntree/pull/1162 .