### PR TITLE
Removed IAanalogSensor interface

### DIFF
--- a/src/devices/realsense2/realsense2Tracking.cpp
+++ b/src/devices/realsense2/realsense2Tracking.cpp
@@ -577,64 +577,6 @@ bool realsense2Tracking::getLinearVelocitySensorMeasure(size_t sens_index, yarp:
     return true;
 }
 
-int realsense2Tracking::read(yarp::sig::Vector& out)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    rs2::frameset dataframe = m_pipeline.wait_for_frames();
-    auto fa = dataframe.first_or_default(RS2_STREAM_POSE);
-    rs2::pose_frame pose = fa.as<rs2::pose_frame>();
-    m_last_pose = pose.get_pose_data();
-
-    out.resize(getChannels());
-    out[0] = m_last_pose.translation.x;
-    out[1] = m_last_pose.translation.y;
-    out[2] = m_last_pose.translation.z;
-    out[3] = m_last_pose.rotation.w;
-    out[4] = m_last_pose.rotation.x;
-    out[5] = m_last_pose.rotation.y;
-    out[6] = m_last_pose.rotation.z;
-    out[7] = m_last_pose.angular_velocity.x;
-    out[8] = m_last_pose.angular_velocity.y;
-    out[9] = m_last_pose.angular_velocity.z;
-    out[10] = m_last_pose.acceleration.x;
-    out[11] = m_last_pose.acceleration.y;
-    out[12] = m_last_pose.acceleration.z;
-    return 0;
-}
-
-int realsense2Tracking::getState(int ch)
-{
-    return 0;
-}
-
-
-int realsense2Tracking::getChannels()
-{
-    return 19;
-}
-
-int realsense2Tracking::calibrateSensor()
-{
-    return 0;
-}
-
-int realsense2Tracking::calibrateSensor(const yarp::sig::Vector& value)
-{
-    return 0;
-}
-
-int realsense2Tracking::calibrateChannel(int ch)
-{
-    return 0;
-}
-
-int realsense2Tracking::calibrateChannel(int ch, double value)
-{
-    return 0;
-}
-
-
-
 
 //-------------------------------------------------------------------------------------------------------
 #if 0

--- a/src/devices/realsense2/realsense2Tracking.h
+++ b/src/devices/realsense2/realsense2Tracking.h
@@ -34,8 +34,7 @@ class realsense2Tracking :
         public yarp::dev::IThreeAxisAngularAccelerometers,
         public yarp::dev::IOrientationSensors,
         public yarp::dev::IPositionSensors,
-        public yarp::dev::ILinearVelocitySensors,
-        public yarp::dev::IAnalogSensor
+        public yarp::dev::ILinearVelocitySensors
 {
 private:
     typedef yarp::os::Stamp Stamp;
@@ -101,14 +100,6 @@ public:
     bool getLinearVelocitySensorFrameName(size_t sens_index, std::string& frameName) const override;
     bool getLinearVelocitySensorMeasure(size_t sens_index, yarp::sig::Vector& xyz, double& timestamp) const override;
 
-    /* IAnalogSensor methods */
-    int read(yarp::sig::Vector &out) override;
-    int getState(int ch) override;
-    int getChannels() override;
-    int calibrateSensor() override;
-    int calibrateSensor(const yarp::sig::Vector& value) override;
-    int calibrateChannel(int ch) override;
-    int calibrateChannel(int ch, double value) override;
 
 #if 0
     /* IPoseSensors methods */


### PR DESCRIPTION
Removed deprecated interface `IAnalogSensor` from device `realsense2Tracking`.
The device already exposes the new interfaces
```
yarp::dev::IThreeAxisGyroscopes
yarp::dev::IThreeAxisLinearAccelerometers
yarp::dev::IThreeAxisAngularAccelerometers
yarp::dev::IOrientationSensors
yarp::dev::IPositionSensors
 ```