### PR TITLE
Added logic to rotate also the ir if specified in the xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Parameters used by this device are:
 |  `stereoMode`                |     -             | bool           | Read / write |         |   false       |  No(see notes)  | Flag for using the realsense as stereo camera                                         |  This option is to use it with yarp::dev::ServerGrabber as network wrapper. The stereo images provided are raw images(yarp::sig::PixelMono) and note that not all the realsense devices have the stereo streams. |
 |  `verbose`                   |     -             | bool           | Read / write |         |   false       |  No             | Flag for enabling debug prints                                                        |                                                                       |
 |  `rotateImage180`            |                   | bool           | Read / write | -       |   -           |  No             | Flag for enabling rotating the image 180 degrees                                      |  Parameter useful when a camera is mounted upside down |
+|  `rotateIRImage180`          |                   | bool           | Read / write | -       |   false       |  No             | Flag for rotating the infrared stereo images 180 degrees                              |  Each infrared image is rotated and their order is corrected for a camera mounted upside down. |
 |  `SETTINGS`                  |     -             | group          | Read / write | -       |   -           |  Yes            | Initial setting of the device.                                                        |  Properties must be read/writable in order for setting to work        |
 |                              | `rgbResolution`   | int, int       | Read / write | pixels  |   -           |  Yes            | Size of rgb image in pixels                                                           |  2 values expected as height, width                                   |
 |                              | `depthResolution` | int, int       | Read / write | pixels  |   -           |  Yes            | Size of depth image in pixels                                                         |  Values are height, width                                             |
@@ -356,4 +357,3 @@ This repository is maintained by:
 | | |
 |:---:|:---:|
 | [<img src="https://github.com/Nicogene.png" width="40">](https://github.com/Nicogene) | [@Nicogene](https://github.com/Nicogene) |
-

--- a/src/devices/realsense2/realsense2Driver.cpp
+++ b/src/devices/realsense2/realsense2Driver.cpp
@@ -874,6 +874,12 @@ bool realsense2Driver::open(Searchable& config)
         }
     }
 
+    if(config.check("rotateIRImage180")){
+        m_rotateIRImage180 = config.find("rotateIRImage180").asBool();
+        if (m_rotateIRImage180) {
+            yCInfo(REALSENSE2) << "parameter rotateIRImage180 enabled, infrared images are rotated";
+        }
+    }
     m_verbose = config.check("verbose");
     
     if (config.check("serialnumber")) {
@@ -1725,6 +1731,24 @@ bool realsense2Driver::getImage(yarp::sig::ImageOf<yarp::sig::PixelMono>& image)
     ImageOf<PixelMono> imgL, imgR;
     imgL.setExternal((unsigned char*) (frm1.get_data()), frm1.get_width(), frm1.get_height());
     imgR.setExternal((unsigned char*) (frm2.get_data()), frm2.get_width(), frm2.get_height());
+
+    if (m_rotateIRImage180)
+    {
+        ImageOf<PixelMono> rotatedL, rotatedR;
+        rotatedL.resize(imgL.width(), imgL.height());
+        rotatedR.resize(imgR.width(), imgR.height());
+        for (size_t y = 0; y < imgL.height(); y++)
+        {
+            for (size_t x = 0; x < imgL.width(); x++)
+            {
+                rotatedL.pixel(x, y) = imgL.pixel(imgL.width() - x - 1, imgL.height() - y - 1);
+                rotatedR.pixel(x, y) = imgR.pixel(imgR.width() - x - 1, imgR.height() - y - 1);
+            }
+        }
+        // A 180-degree correction also reverses the physical left/right sensor order.
+        return utils::horzConcat(rotatedR, rotatedL, image);
+    }
+
     return utils::horzConcat(imgL, imgR, image);
 }
 

--- a/src/devices/realsense2/realsense2Driver.h
+++ b/src/devices/realsense2/realsense2Driver.h
@@ -149,6 +149,7 @@ protected:
     float m_scale;
     bool m_rotateImage180{false};
     std::string m_serialnumber;
+    bool m_rotateIRImage180{false};
     std::vector<cameraFeature_id_t> m_supportedFeatures;
 
     // Depth post-processing filters


### PR DESCRIPTION
In this PR I have added the possibility to rotate also the infrared data of the camera if specified in the xml of the realsense.
